### PR TITLE
Always Make the Call, But Selectively Decide Whether or Not to Notify the User

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Then, in `applicationDidFinishLaunching:withOptions`, I configured `Retired` wit
 ```swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
   let versionURL              = NSURL(string: "https://example.com/versions.json")!
-  let intervalBetweenRequests = 60 * 60 * 24 // one day
+  let intervalBetweenRequests = 60 * 60 * 24 // one day between recommended app updates
 
   Retired.configure(versionURL, suppressionInterval: intervalBetweenRequests)
   return true

--- a/Sources/Retired.swift
+++ b/Sources/Retired.swift
@@ -28,7 +28,6 @@ public class Retired {
   }
 
   public static func check(completion: RetiredCompletion) throws {
-    guard shouldPerformCheck() else { return }
     guard let fetcher = fetcher else { throw RetiredError.NotConfigured }
 
     fetcher.check() { forcedUpdate, message, error in
@@ -36,6 +35,9 @@ public class Retired {
         completion(false, nil, error)
         return
       }
+
+      // skip the completion block unless it's a forced update or the suppression interval has lapsed
+      guard forcedUpdate || suppressionWindowLapsed() else { return }
 
       if forcedUpdate {
         nextRequestDate.clear()
@@ -51,7 +53,7 @@ public class Retired {
     nextRequestDate.value = nil
   }
 
-  private static func shouldPerformCheck() -> Bool {
+  private static func suppressionWindowLapsed() -> Bool {
     if let suppressionDate = nextRequestDate.value {
       return suppressionDate.compare(NSDate()) != .OrderedDescending
     }


### PR DESCRIPTION
@nsimmons @raulriera 
# The Problem

When using the `suppressionInterval` there's a case that's not handled well. When the user receives a `recommend` update notice and cancels, no other checks will go out until the window has lapsed.

This is can be an issue when you change a recommended policy to forced. Until the window lapses no other checks will be performed (dead versions will still try to function and may crash due to incompatibility).
# The Solution

Always make the call. But, when the policy returns `recommended` only call the completion block if the suppression window has lapsed.
